### PR TITLE
Snare didn't play out of the box

### DIFF
--- a/maximilian.h
+++ b/maximilian.h
@@ -710,7 +710,7 @@ public:
     double envOut;
     bool useDistortion = false;
     bool useLimiter = false;
-    bool useFilter = true;
+    bool useFilter = false;
     double distortion = 0;
     bool inverse = false;
     double cutoff;


### PR DESCRIPTION
Snare was set to useFilter but cutoff and resonance aren't initialised in the constructor resulting in a mute snare compared to kick and hats.